### PR TITLE
Add option to use IHttpClientFactory to create HttpClients

### DIFF
--- a/src/Sanity.Linq/Sanity.Linq.csproj
+++ b/src/Sanity.Linq/Sanity.Linq.csproj
@@ -59,6 +59,7 @@ This file is part of Sanity LINQ (https://github.com/oslofjord/sanity-linq).
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 

--- a/src/Sanity.Linq/SanityClient.cs
+++ b/src/Sanity.Linq/SanityClient.cs
@@ -38,14 +38,16 @@ namespace Sanity.Linq
     public class SanityClient
     {
         protected SanityOptions _options;
+        private IHttpClientFactory _factory;
         private HttpClient _httpQueryClient;
         private HttpClient _httpClient;
 
         public JsonSerializerSettings SerializerSettings { get; }
 
-        public SanityClient(SanityOptions options, JsonSerializerSettings serializerSettings = null)
+        public SanityClient(SanityOptions options, JsonSerializerSettings serializerSettings = null, IHttpClientFactory clientFactory = null)
         {
             _options = options;
+            _factory = clientFactory;
             SerializerSettings = serializerSettings ?? new JsonSerializerSettings
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),
@@ -60,7 +62,7 @@ namespace Sanity.Linq
             // Initialize serialization settings
 
             // Initialize query client
-            _httpQueryClient = new HttpClient();
+            _httpQueryClient = _factory?.CreateClient() ?? new HttpClient();
             _httpQueryClient.DefaultRequestHeaders.Accept.Clear();
             _httpQueryClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             if (_options.UseCdn)
@@ -83,7 +85,7 @@ namespace Sanity.Linq
             }
             else
             {
-                _httpClient = new HttpClient();
+                _httpClient = _factory?.CreateClient() ?? new HttpClient();
                 _httpClient.DefaultRequestHeaders.Accept.Clear();
                 _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 _httpClient.BaseAddress = new Uri($"https://{WebUtility.UrlEncode(_options.ProjectId)}.api.sanity.io/v1/");

--- a/src/Sanity.Linq/SanityDataContext.cs
+++ b/src/Sanity.Linq/SanityDataContext.cs
@@ -61,7 +61,7 @@ namespace Sanity.Linq
         /// </summary>
         /// <param name="options"></param>
         /// <param name="isShared">Indicates that the context can be used by multiple SanityDocumentSets</param>
-        public SanityDataContext(SanityOptions options, JsonSerializerSettings serializerSettings = null, SanityHtmlBuilderOptions htmlBuilderOptions = null)
+        public SanityDataContext(SanityOptions options, JsonSerializerSettings serializerSettings = null, SanityHtmlBuilderOptions htmlBuilderOptions = null, IHttpClientFactory clientFactory = null)
         {
             if (options == null)
             {
@@ -73,7 +73,7 @@ namespace Sanity.Linq
                 NullValueHandling = NullValueHandling.Ignore,
                 Converters = new List<JsonConverter> { new SanityReferenceTypeConverter() }
             };
-            Client = new SanityClient(options, serializerSettings);
+            Client = new SanityClient(options, serializerSettings, clientFactory);
             Mutations = new SanityMutationBuilder(Client);
             HtmlBuilder = new SanityHtmlBuilder(options, null, SerializerSettings, htmlBuilderOptions);
         }


### PR DESCRIPTION
Background:

`SanityDataContext` creates a new instance of `SanityClient`:

https://github.com/oslofjord/sanity-linq/blob/master/src/Sanity.Linq/SanityDataContext.cs#L76

which in turn creates new instances of `HttpClient`:

https://github.com/oslofjord/sanity-linq/blob/master/src/Sanity.Linq/SanityClient.cs#L63
https://github.com/oslofjord/sanity-linq/blob/master/src/Sanity.Linq/SanityClient.cs#L86

This may cause issues, as described here:
https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests

The ususal fix is to use `IHttpClientFactory` instead of depending on `new` when handling `HttpClient` :
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-3.1#basic-usage

This PR adds `IHttpClientFactory` to constructor params (as optional parameter to keep backwards compatibility) that allows to inject it and avoid issues mentioned above.