### PR TITLE
Add build context to HtmlBuilder and custom markDef serializers

### DIFF
--- a/src/Sanity.Linq/BlockContent/SanityHtmlSerializers.cs
+++ b/src/Sanity.Linq/BlockContent/SanityHtmlSerializers.cs
@@ -10,7 +10,7 @@ namespace Sanity.Linq.BlockContent
     public class SanityHtmlSerializers
     {
         // Sanity Default Serializers
-        public Task<string> SerializeDefaultBlockAsync(JToken input, SanityOptions sanity)
+        public Task<string> SerializeDefaultBlockAsync(JToken input, SanityOptions sanity, object context = null)
         {
             var text = new StringBuilder();
             var listStart = new StringBuilder();
@@ -102,7 +102,11 @@ namespace Sanity.Linq.BlockContent
                         var markDef = markDefs?.FirstOrDefault(m => m["_key"]?.ToString() == sMark);                       
                         if (markDef != null)
                         {
-                            if (markDef["_type"]?.ToString() == "link")
+                            if (TrySerializeMarkDef(markDef, context, ref start, ref end))
+                            {
+                                continue;
+                            }
+                            else if (markDef["_type"]?.ToString() == "link")
                             {
                                 start.Append($"<a target=\"_blank\" href=\"{markDef["href"]?.ToString()}\">");
                                 end.Append( "</a>");
@@ -135,6 +139,7 @@ namespace Sanity.Linq.BlockContent
 
             //return listStart + listItemStart + "<" + tag + ">" + text + "</" + tag + ">" + listItemEnd + listEnd;
         }
+
         public Task<string> SerializeImageAsync(JToken input, SanityOptions options)
         {
             var asset = input["asset"];
@@ -174,5 +179,7 @@ namespace Sanity.Linq.BlockContent
 
             return Task.FromResult(html);
         }
+
+        protected virtual bool TrySerializeMarkDef(JToken markDef, object context, ref StringBuilder start, ref StringBuilder end) => false;
     }
 }

--- a/src/Sanity.Linq/Extensions/SanityDataContextExtensions.cs
+++ b/src/Sanity.Linq/Extensions/SanityDataContextExtensions.cs
@@ -29,7 +29,12 @@ namespace Sanity.Linq
 {
     public static class SanityDataContextExtensions
     {
-        public static void AddHtmlSerializer(this SanityDataContext sanity, string type, Func<JToken, SanityOptions,Task<string>> serializer)
+        public static void AddHtmlSerializer(this SanityDataContext sanity, string type, Func<JToken, SanityOptions, Task<string>> serializer)
+        {
+            sanity.HtmlBuilder.AddSerializer(type, serializer);
+        }
+
+        public static void AddHtmlSerializer(this SanityDataContext sanity, string type, Func<JToken, SanityOptions,object,Task<string>> serializer)
         {
             sanity.HtmlBuilder.AddSerializer(type, serializer);
         }

--- a/src/Sanity.Linq/Extensions/SanityDocumentExtensions.cs
+++ b/src/Sanity.Linq/Extensions/SanityDocumentExtensions.cs
@@ -280,22 +280,42 @@ namespace Sanity.Linq.Extensions
 
         public static Task<string> ToHtmlAsync(this object blockContent, SanityHtmlBuilder builder)
         {
-            return builder.BuildAsync(blockContent);
+            return blockContent.ToHtmlAsync(builder, null);
+        }
+
+        public static Task<string> ToHtmlAsync(this object blockContent, SanityHtmlBuilder builder, object buildContext = null)
+        {
+            return builder.BuildAsync(blockContent, buildContext);
         }
 
         public static string ToHtml(this object blockContent, SanityHtmlBuilder builder)
         {
-            return builder.BuildAsync(blockContent).Result;
+            return blockContent.ToHtml(builder, null);
+        }
+
+        public static string ToHtml(this object blockContent, SanityHtmlBuilder builder, object buildContext)
+        {
+            return builder.BuildAsync(blockContent, buildContext).Result;
         }
 
         public static Task<string> ToHtmlAsync(this object blockContent, SanityDataContext context)
         {
-            return context.HtmlBuilder.BuildAsync(blockContent);
+            return blockContent.ToHtmlAsync(context, null);
+        }
+
+        public static Task<string> ToHtmlAsync(this object blockContent, SanityDataContext context, object buildContext)
+        {
+            return context.HtmlBuilder.BuildAsync(blockContent, buildContext);
         }
 
         public static string ToHtml(this object blockContent, SanityDataContext context)
         {
-            return context.HtmlBuilder.BuildAsync(blockContent).Result;
+            return blockContent.ToHtml(context, null);
+        }
+
+        public static string ToHtml(this object blockContent, SanityDataContext context, object buildContext)
+        {
+            return context.HtmlBuilder.BuildAsync(blockContent, buildContext).Result;
         }
     }
 }

--- a/tests/Sanity.Linq.Tests/BlockConvertTest.cs
+++ b/tests/Sanity.Linq.Tests/BlockConvertTest.cs
@@ -22,7 +22,7 @@ namespace Sanity.Linq.Tests
             var htmlBuilder = new SanityHtmlBuilder(Options);
             foreach (var post in posts)
             {
-                var html = htmlBuilder.BuildAsync(post.Body); // the serialized data
+                var html = htmlBuilder.BuildAsync(post.Body, null); // the serialized data
             }
         }
 


### PR DESCRIPTION
- Added build context to SanityHtmlBuilder to pass some context when building the html markup.

- Added possibility to extend built in SanityHtmlSerializers. By inheriting the built in SanityHtmlSerializers and overriding TrySerializeMarkDef,
a custom implementation can use the built in functionality for common block content and at the same time implement own functionality for custom annotations