### PR TITLE
Added support for choosing API-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ var options = new SanityOptions
             ProjectId = "#your-project-id#",
             Dataset = "#your-dataset#",
             Token = "#your-token#",
-            UseCdn = false
+            UseCdn = false,
+            ApiVersion = "v1"
         };
 
 var sanity = new SanityDataContext(options);

--- a/src/Sanity.Linq/Sanity.Linq.csproj
+++ b/src/Sanity.Linq/Sanity.Linq.csproj
@@ -26,7 +26,7 @@ This file is part of Sanity LINQ (https://github.com/oslofjord/sanity-linq).
     <Authors>Oslofjord Operations AS</Authors>
     <Company>Oslofjord Operations AS</Company>
     <Product>Sanity LINQ</Product>
-    <Version>1.4.4</Version>
+    <Version>1.4.5</Version>
     <Description>Strongly-typed .Net Client for Sanity CMS (https://sanity.io)</Description>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Copyright>2018 Oslofjord Operations AS</Copyright>
@@ -35,11 +35,11 @@ This file is part of Sanity LINQ (https://github.com/oslofjord/sanity-linq).
     <RepositoryType>git</RepositoryType>
     <PackageTags>sanity cms dotnet linq client groq</PackageTags>
     <PackageLicenseUrl>https://raw.githubusercontent.com/oslofjord/sanity-linq/master/LICENSE</PackageLicenseUrl>
-    <AssemblyVersion>1.4.4.0</AssemblyVersion>
+    <AssemblyVersion>1.4.5.0</AssemblyVersion>
     <PackageId>Sanity.Linq</PackageId>
     <AssemblyName>Sanity.Linq</AssemblyName>
     <RootNamespace>Sanity.Linq</RootNamespace>
-    <FileVersion>1.4.4.0</FileVersion>
+    <FileVersion>1.4.5.0</FileVersion>
     <PackageReleaseNotes>1.0 - Sanity Linq library
 1.1 - BlockContent library
 1.1.1 - Improvements BlockContent
@@ -55,9 +55,11 @@ This file is part of Sanity LINQ (https://github.com/oslofjord/sanity-linq).
 1.3.9 - Added support for sanity _key field to SanityDocument common type
 1.4.0 - Support for cancellation tokens
 1.4.1 - Bugfix for weak references
-1.4.2 -Support for "Contains" queries
+1.4.2 - Support for "Contains" queries
 1.4.3 - Support for IHttpClientFactory
-1.4.4 - SanityFile type added</PackageReleaseNotes>
+1.4.4 - SanityFile type added
+1.4.5 - Added support for choosing API-version
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sanity.Linq/SanityClient.cs
+++ b/src/Sanity.Linq/SanityClient.cs
@@ -65,11 +65,11 @@ namespace Sanity.Linq
             _httpQueryClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             if (_options.UseCdn)
             {
-                _httpQueryClient.BaseAddress = new Uri($"https://{WebUtility.UrlEncode(_options.ProjectId)}.apicdn.sanity.io/v1/");
+                _httpQueryClient.BaseAddress = new Uri($"https://{WebUtility.UrlEncode(_options.ProjectId)}.apicdn.sanity.io/{_options.ApiVersion}/");
             }
             else
             {
-                _httpQueryClient.BaseAddress = new Uri($"https://{WebUtility.UrlEncode(_options.ProjectId)}.api.sanity.io/v1/");
+                _httpQueryClient.BaseAddress = new Uri($"https://{WebUtility.UrlEncode(_options.ProjectId)}.api.sanity.io/{_options.ApiVersion}/");
             }
             if (!string.IsNullOrEmpty(_options.Token) && !_options.UseCdn)
             {
@@ -86,7 +86,7 @@ namespace Sanity.Linq
                 _httpClient = _factory?.CreateClient() ?? new HttpClient();
                 _httpClient.DefaultRequestHeaders.Accept.Clear();
                 _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                _httpClient.BaseAddress = new Uri($"https://{WebUtility.UrlEncode(_options.ProjectId)}.api.sanity.io/v1/");
+                _httpClient.BaseAddress = new Uri($"https://{WebUtility.UrlEncode(_options.ProjectId)}.api.sanity.io/{_options.ApiVersion}/");
                 if (!string.IsNullOrEmpty(_options.Token))
                 {
                     _httpQueryClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _options.Token);

--- a/src/Sanity.Linq/SanityOptions.cs
+++ b/src/Sanity.Linq/SanityOptions.cs
@@ -25,5 +25,7 @@ namespace Sanity.Linq
         public string Token { get; set; }
 
         public bool UseCdn { get; set; }
+
+        public string ApiVersion { get; set; } = "v1";
     }
 }


### PR DESCRIPTION
It would be nice to have the abillity to choose API-version, like in the JS client. See https://www.sanity.io/docs/api-versioning

To be able to use the new [geospatial queries](https://www.sanity.io/changelog#change-723465cf-54e9-49e1-9591-a50672e286bc) added in v2021-03-25, the calls must be made to a newer version of the API.

The new option will default to v1 if not set.