### PR TITLE
🐛 Remove generic `1 marker from Sanity type name

### DIFF
--- a/src/Sanity.Linq/Extensions/SanityExtensions.cs
+++ b/src/Sanity.Linq/Extensions/SanityExtensions.cs
@@ -15,8 +15,6 @@
 
 using Sanity.Linq.CommonTypes;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Sanity.Linq.Extensions
 {
@@ -41,8 +39,10 @@ namespace Sanity.Linq.Extensions
                     }
                 default:
                     {
-                        // Remove Sanity from class name
-                        var name = type.Name.Replace("Sanity", "");
+                        // Remove Sanity and generic type marker from class name
+                        var name = type.Name
+                            .Replace("Sanity", "")
+                            .Replace("`1", "");
 
                         //Make first letter lowercase (i.e. camelCase)
                         return name.ToCamelCase();


### PR DESCRIPTION
The generated Sanity type name for generic classes would include the `` `1`` marker when translated to a Sanity type name. This means that e.g. `SanityReference<T>` would be translated to ``reference`1``, whilst it should be just `reference`.

Changed `GetSanityTypeName` to remove `` `1`` from the generated type name.