### PR TITLE
⬇️ Downgrade test project to netcoreapp3.1

### DIFF
--- a/tests/Sanity.Linq.Tests/Sanity.Linq.Tests.csproj
+++ b/tests/Sanity.Linq.Tests/Sanity.Linq.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
The build pipeline was failing, probably because the Test project had been upgraded to `net6.0`. This PR downgrades it to `netcoreapp3.1`.