### PR TITLE
🐛 Fix support for queries with parameters against CDN endpoint

### DIFF
--- a/src/Sanity.Linq/Sanity.Linq.csproj
+++ b/src/Sanity.Linq/Sanity.Linq.csproj
@@ -26,7 +26,7 @@ This file is part of Sanity LINQ (https://github.com/oslofjord/sanity-linq).
     <Authors>Oslofjord Operations AS</Authors>
     <Company>Oslofjord Operations AS</Company>
     <Product>Sanity LINQ</Product>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <Description>Strongly-typed .Net Client for Sanity CMS (https://sanity.io)</Description>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Copyright>2018 Oslofjord Operations AS</Copyright>
@@ -35,11 +35,11 @@ This file is part of Sanity LINQ (https://github.com/oslofjord/sanity-linq).
     <RepositoryType>git</RepositoryType>
     <PackageTags>sanity cms dotnet linq client groq</PackageTags>
     <PackageLicenseUrl>https://raw.githubusercontent.com/oslofjord/sanity-linq/master/LICENSE</PackageLicenseUrl>
-    <AssemblyVersion>1.5.0.0</AssemblyVersion>
+    <AssemblyVersion>1.6.0.0</AssemblyVersion>
     <PackageId>Sanity.Linq</PackageId>
     <AssemblyName>Sanity.Linq</AssemblyName>
     <RootNamespace>Sanity.Linq</RootNamespace>
-    <FileVersion>1.5.0.0</FileVersion>
+    <FileVersion>1.6.0.0</FileVersion>
     <PackageReleaseNotes>1.0 - Sanity Linq library
 1.1 - BlockContent library
 1.1.1 - Improvements BlockContent
@@ -60,6 +60,7 @@ This file is part of Sanity LINQ (https://github.com/oslofjord/sanity-linq).
 1.4.4 - SanityFile type added
 1.4.5 - Added support for choosing API-version
 1.5.0 - Updated dependencies and support for source link, some serialization fixes
+1.6.0 - Fixed support for queries with parameters against the CDN endpoint
     </PackageReleaseNotes>
 
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/tests/Sanity.Linq.Tests/Sanity.Linq.Tests.csproj
+++ b/tests/Sanity.Linq.Tests/Sanity.Linq.Tests.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
The CDN endpoint now does support POST requests for queries (which are also cached since they are read only). Also, added the token to the CDN endpoint as well because it also needs it for returning data.