### PR TITLE
♻️ Allow for overriding JsonSerializerSettings for serialization and deserialization

### DIFF
--- a/src/Sanity.Linq/SanityClient.cs
+++ b/src/Sanity.Linq/SanityClient.cs
@@ -41,17 +41,26 @@ namespace Sanity.Linq
         private HttpClient _httpClient;
 
         public JsonSerializerSettings SerializerSettings { get; }
+        public JsonSerializerSettings DeserializerSettings { get; }
 
-        public SanityClient(SanityOptions options, JsonSerializerSettings serializerSettings = null, IHttpClientFactory clientFactory = null)
+        public SanityClient(SanityOptions options, JsonSerializerSettings serializerSettings = null, IHttpClientFactory clientFactory = null) : this(options, serializerSettings, serializerSettings, clientFactory)
+        { }
+
+        public SanityClient(SanityOptions options, JsonSerializerSettings serializerSettings, JsonSerializerSettings deserializerSettings, IHttpClientFactory clientFactory = null)
         {
             _options = options;
             _factory = clientFactory;
-            SerializerSettings = serializerSettings ?? new JsonSerializerSettings
+
+            var defaultSerializerSettings = new JsonSerializerSettings
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),
                 NullValueHandling = NullValueHandling.Ignore,
                 Converters = new List<JsonConverter> { new SanityReferenceTypeConverter() }
             };
+
+            SerializerSettings = serializerSettings ?? defaultSerializerSettings;
+            DeserializerSettings = deserializerSettings ?? defaultSerializerSettings;
+
             Initialize();
         }
 
@@ -220,7 +229,7 @@ namespace Sanity.Linq
             {
                 try
                 {
-                    return JsonConvert.DeserializeObject<TResponse>(content, SerializerSettings);
+                    return JsonConvert.DeserializeObject<TResponse>(content, DeserializerSettings);
                 }
                 catch (Exception ex)
                 {

--- a/tests/Sanity.Linq.Tests/BlockConvertTest.cs
+++ b/tests/Sanity.Linq.Tests/BlockConvertTest.cs
@@ -1,11 +1,8 @@
-﻿using Newtonsoft.Json.Linq;
-using Sanity.Linq.BlockContent;
+﻿using Sanity.Linq.BlockContent;
 using Sanity.Linq.CommonTypes;
 using Sanity.Linq.Demo.Model;
 using Sanity.Linq.Extensions;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 


### PR DESCRIPTION
Adds constructor parameters for explicitly overriding `JsonSerializerSettings` for serialization and deserialization separately. We use this for deserializing certain computed/readonly properties from Sanity, but not serializing them back when sending data to Sanity (as this would store these fields in our documents).

Made sure that the original `ctor` behaves the same as before by using the same `JsonSerializerSettings` on both serialization and deserialization.