### PR TITLE
Safe-guard ApiVersion and Ensure 'v' prefix

### DIFF
--- a/src/Sanity.Linq/SanityOptions.cs
+++ b/src/Sanity.Linq/SanityOptions.cs
@@ -14,6 +14,8 @@
 //  along with this program.
 
 
+using System;
+
 namespace Sanity.Linq
 {
     public class SanityOptions
@@ -26,6 +28,22 @@ namespace Sanity.Linq
 
         public bool UseCdn { get; set; }
 
-        public string ApiVersion { get; set; } = "v1";
+        private string _apiVersion = "v1";
+        
+        /// <summary>
+        /// The Sanity API version to use. Defaults to v1. Prefixes with "v" if not present as prefix.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If you try to set ApiVersion = null</exception>
+        public string ApiVersion
+        {
+            get => _apiVersion;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("ApiVersion cannot be set to null");
+                
+                _apiVersion = value.StartsWith("v") ? value : $"v{value}";
+            }
+        }
     }
 }


### PR DESCRIPTION
After discovering (using Fiddler) that 'v' needs to be the prefix in `ApiVersion`, I recommend having it ensured automatically and silently, or else we'll get 404s unnecessarily. E.g. when having an API version that is a date, I had to prefix with 'v', but didn't need to do that in a JavaScript (SanityClient) integration to the same API. Also, whether `ApiVersion` can be `null` is not really investigated, but I bet it also makes more sense to not allow it to be `null` than to allow it, so that is also included here.  

In other words, this PR makes it possible to have the exact same Sanity options as you would have in a JS (or Next) project using SanityClient (where ApiVersion without a 'v' prefix is supported). 