### PR TITLE
SanityImageAsset: Alternative text + include in SanityImageAsset reference object

### DIFF
--- a/src/Sanity.Linq/BlockContent/SanityHtmlSerializers.cs
+++ b/src/Sanity.Linq/BlockContent/SanityHtmlSerializers.cs
@@ -19,7 +19,7 @@ namespace Sanity.Linq.BlockContent
             var listItemEnd = new StringBuilder();
 
             var text2 = new StringBuilder();
-            
+
 
             // get style
             var tag = "";
@@ -27,7 +27,7 @@ namespace Sanity.Linq.BlockContent
             {
                 tag = "p";
             }
-            else 
+            else
             {
                 //default to span
                 tag = input["style"]?.ToString() ?? "span";
@@ -99,7 +99,7 @@ namespace Sanity.Linq.BlockContent
                     foreach (var mark in child["marks"])
                     {
                         var sMark = mark?.ToString();
-                        var markDef = markDefs?.FirstOrDefault(m => m["_key"]?.ToString() == sMark);                       
+                        var markDef = markDefs?.FirstOrDefault(m => m["_key"]?.ToString() == sMark);
                         if (markDef != null)
                         {
                             if (TrySerializeMarkDef(markDef, context, ref start, ref end))
@@ -144,6 +144,8 @@ namespace Sanity.Linq.BlockContent
         {
             var asset = input["asset"];
             var imageRef = asset?["_ref"]?.ToString();
+            var assetValue = asset?["value"];
+            var imageAltText = assetValue?["altText"];
 
             if (asset == null || imageRef == null)
             {
@@ -168,15 +170,12 @@ namespace Sanity.Linq.BlockContent
                 url.Append(imageParts[2]     + ".");             // dimensions.
                 url.Append(imageParts[3]);                       // file extension
                 url.Append(parameters.ToString());                          // ?crop etc..
-                
-            return Task.FromResult($"<figure><img src=\"{url}\"/></figure>");
+
+            return Task.FromResult($"<figure><img src=\"{url}\" alt=\"{imageAltText}\"/></figure>");
         }
         public Task<string> SerializeTableAsync(JToken input, SanityOptions options)
         {
             var html = "";
-
-
-
             return Task.FromResult(html);
         }
 

--- a/src/Sanity.Linq/BlockContent/SanityHtmlSerializers.cs
+++ b/src/Sanity.Linq/BlockContent/SanityHtmlSerializers.cs
@@ -145,7 +145,7 @@ namespace Sanity.Linq.BlockContent
             var asset = input["asset"];
             var imageRef = asset?["_ref"]?.ToString();
             var assetValue = asset?["value"];
-            var imageAltText = assetValue?["altText"];
+            var imageAltText = assetValue?["altText"] ?? "";
 
             if (asset == null || imageRef == null)
             {

--- a/src/Sanity.Linq/CommonTypes/SanityBlock.cs
+++ b/src/Sanity.Linq/CommonTypes/SanityBlock.cs
@@ -16,6 +16,7 @@ namespace Sanity.Linq.CommonTypes
 
         public object[] Children { get; set; } = new object[] { };
 
+        [Include]
         public SanityReference<SanityImageAsset> Asset { get; set; } = new SanityReference<SanityImageAsset> { };
 
         public int? Level { get; set; }

--- a/src/Sanity.Linq/CommonTypes/SanityImage.cs
+++ b/src/Sanity.Linq/CommonTypes/SanityImage.cs
@@ -28,6 +28,7 @@ namespace Sanity.Linq.CommonTypes
             SanityType = "image";
         }
 
+        [Include]
         public SanityReference<SanityImageAsset> Asset { get; set; }
 
         public SanityImageCrop Crop { get; set; }

--- a/src/Sanity.Linq/CommonTypes/SanityImageAsset.cs
+++ b/src/Sanity.Linq/CommonTypes/SanityImageAsset.cs
@@ -26,6 +26,9 @@ namespace Sanity.Linq.CommonTypes
         {
             Type = "sanity.imageAsset";
         }
+
+        [JsonProperty("altText")]
+        public string AltText { get; set; }
     }
 
     public class SanityImageAssetReference : SanityImageAsset

--- a/src/Sanity.Linq/JsonConverters/SanityReferenceTypeConverter.cs
+++ b/src/Sanity.Linq/JsonConverters/SanityReferenceTypeConverter.cs
@@ -66,6 +66,7 @@ namespace Sanity.Linq
 
                 //Get reference from object
                 var valRef = type.GetProperty("Ref").GetValue(value) as string;
+                object Value = null;
 
                 // Alternatively, get reference from Id on nested Value
                 if (string.IsNullOrEmpty(valRef))
@@ -82,6 +83,14 @@ namespace Sanity.Linq
                         }
                     }
                 }
+                else
+                {
+                    var propValue = type.GetProperty("Value");
+                    if (propValue != null)
+                    {
+                        Value = propValue.GetValue(value);
+                    }
+                }
 
                 // Get _key property (required for arrays in sanity editor)
                 var keyProp = type.GetProperties().FirstOrDefault(p => p.Name.ToLower() == "_key" || ((p.GetCustomAttributes(typeof(JsonPropertyAttribute), true).FirstOrDefault() as JsonPropertyAttribute)?.PropertyName?.Equals("_key")).GetValueOrDefault());
@@ -89,9 +98,10 @@ namespace Sanity.Linq
                 var valKey = keyProp?.GetValue(value) as string ?? Guid.NewGuid().ToString();
                 var valWeak = weakProp?.GetValue(value) as bool? ?? null;
 
+
                 if (!string.IsNullOrEmpty(valRef))
                 {
-                    serializer.Serialize(writer, new { _ref = valRef, _type = "reference", _key = valKey, _weak = valWeak });
+                    serializer.Serialize(writer, new { _ref = valRef, _type = "reference", _key = valKey, _weak = valWeak, value = Value });
                     return;
                 }
             }

--- a/src/Sanity.Linq/JsonConverters/SanityReferenceTypeConverter.cs
+++ b/src/Sanity.Linq/JsonConverters/SanityReferenceTypeConverter.cs
@@ -58,22 +58,22 @@ namespace Sanity.Linq
             return null;
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object objectToSerialize, JsonSerializer serializer)
         {
-            if (value != null)
+            if (objectToSerialize != null)
             {
-                var type = value.GetType();
+                var objectType = objectToSerialize.GetType();
 
                 //Get reference from object
-                var valRef = type.GetProperty("Ref").GetValue(value) as string;
-                object Value = null;
+                var valRef = objectType.GetProperty("Ref").GetValue(objectToSerialize) as string;
+                object objectToSerializePropValue = null;
 
+                var propValue = objectType.GetProperty("Value");
                 // Alternatively, get reference from Id on nested Value
-                if (string.IsNullOrEmpty(valRef))
+                if (string.IsNullOrEmpty(valRef) && propValue != null)
                 {
-                    var propValue = type.GetProperty("Value");
-                    var valValue = propValue.GetValue(value);
-                    if (propValue != null && valValue != null)
+                    var valValue = propValue.GetValue(objectToSerialize);
+                    if (valValue != null)
                     {
                         var valType = propValue.PropertyType;
                         var idProp = valType.GetProperties().FirstOrDefault(p => p.Name.ToLower() == "_id" || ((p.GetCustomAttributes(typeof(JsonPropertyAttribute), true).FirstOrDefault() as JsonPropertyAttribute)?.PropertyName?.Equals("_id")).GetValueOrDefault());
@@ -83,25 +83,22 @@ namespace Sanity.Linq
                         }
                     }
                 }
-                else
+
+                if (!string.IsNullOrEmpty(valRef) && propValue != null)
                 {
-                    var propValue = type.GetProperty("Value");
-                    if (propValue != null)
-                    {
-                        Value = propValue.GetValue(value);
-                    }
+                    objectToSerializePropValue = propValue.GetValue(objectToSerialize);
                 }
 
                 // Get _key property (required for arrays in sanity editor)
-                var keyProp = type.GetProperties().FirstOrDefault(p => p.Name.ToLower() == "_key" || ((p.GetCustomAttributes(typeof(JsonPropertyAttribute), true).FirstOrDefault() as JsonPropertyAttribute)?.PropertyName?.Equals("_key")).GetValueOrDefault());
-                var weakProp = type.GetProperties().FirstOrDefault(p => p.Name.ToLower() == "_weak" || ((p.GetCustomAttributes(typeof(JsonPropertyAttribute), true).FirstOrDefault() as JsonPropertyAttribute)?.PropertyName?.Equals("_weak")).GetValueOrDefault());
-                var valKey = keyProp?.GetValue(value) as string ?? Guid.NewGuid().ToString();
-                var valWeak = weakProp?.GetValue(value) as bool? ?? null;
+                var keyProp = objectType.GetProperties().FirstOrDefault(p => p.Name.ToLower() == "_key" || ((p.GetCustomAttributes(typeof(JsonPropertyAttribute), true).FirstOrDefault() as JsonPropertyAttribute)?.PropertyName?.Equals("_key")).GetValueOrDefault());
+                var weakProp = objectType.GetProperties().FirstOrDefault(p => p.Name.ToLower() == "_weak" || ((p.GetCustomAttributes(typeof(JsonPropertyAttribute), true).FirstOrDefault() as JsonPropertyAttribute)?.PropertyName?.Equals("_weak")).GetValueOrDefault());
+                var valKey = keyProp?.GetValue(objectToSerialize) as string ?? Guid.NewGuid().ToString();
+                var valWeak = weakProp?.GetValue(objectToSerialize) as bool? ?? null;
 
 
                 if (!string.IsNullOrEmpty(valRef))
                 {
-                    serializer.Serialize(writer, new { _ref = valRef, _type = "reference", _key = valKey, _weak = valWeak, value = Value });
+                    serializer.Serialize(writer, new { _ref = valRef, _type = "reference", _key = valKey, _weak = valWeak, value = objectToSerializePropValue });
                     return;
                 }
             }


### PR DESCRIPTION
Images can have alternative text defined via the media plugin, but with the current version of Sanity.Linq, this text is not included with images.

We have added `[Include]` to `SanityReference<SanityImageAsset> Asset` property in `SanityBlock`, further `AltText` property is added to `SanityImageAsset`. 

We noticed that when adding an image inside a block editor, the image object we get from Sanity.Linq is only a reference. In this case, alternative text is added by including the original `Value` object on the reference in the `SanityReferenceTypeConverter`, and included into the default image html serializer.

Please provide feedback if you see anything wrong with this solution and feel free to make changes.