### PR TITLE
Provide correct serializer settings to sanity client

### DIFF
--- a/src/Sanity.Linq/SanityDataContext.cs
+++ b/src/Sanity.Linq/SanityDataContext.cs
@@ -76,7 +76,7 @@ namespace Sanity.Linq
 
             SerializerSettings = serializerSettings ?? defaultSerializerSettings;
             DeserializerSettings = deserializerSettings ?? defaultSerializerSettings;
-            Client = new SanityClient(options, serializerSettings, defaultSerializerSettings, clientFactory);
+            Client = new SanityClient(options, SerializerSettings, DeserializerSettings, clientFactory);
             Mutations = new SanityMutationBuilder(Client);
             HtmlBuilder = new SanityHtmlBuilder(options, null, SerializerSettings, htmlBuilderOptions);
         }


### PR DESCRIPTION
I went to implement a custom JsonConverter to do some specific deserialization logic, and realized that the DeserializerSettings I'm providing to the data context aren't getting used