### PR TITLE
Replaced ï with i in test because it causes encoding problems

### DIFF
--- a/tests/Sanity.Linq.Tests/QueryTests.cs
+++ b/tests/Sanity.Linq.Tests/QueryTests.cs
@@ -62,8 +62,8 @@ namespace Sanity.Linq.Tests
             var result1 = await categories.Where(c => namesToFind.Contains(c.Title)).ToListAsync();
             Assert.True(result1.Count == 2);
 
-            var ïdsToFind = new List<int> { 1, 2 };
-            var result2 = await categories.Where(c => ïdsToFind.Contains(c.InternalId)).ToListAsync();
+            var idsToFind = new List<int> { 1, 2 };
+            var result2 = await categories.Where(c => idsToFind.Contains(c.InternalId)).ToListAsync();
             Assert.True(result2.Count == 2);
 
 


### PR DESCRIPTION
The QueryTest contains a weird character i with umlaut and the file is not UTF8 encoded. 

This causes issues on systems with other standard encoding ie. OSX. I just replaced the ï with a regular i